### PR TITLE
fix(accept waf name config):  Allow user to specify a waf name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export class WafPlugin {
       }));
     };
     // set the waf name based on stage and service name ${self:service}-${self:custom.stage}-webacl
-    const wafName = `${
+    const wafName = this.config?.name || `${
       this.serverless.service.custom.stage
     }-${this.serverless.service.getServiceName()}-webacl`;
 


### PR DESCRIPTION
You may now specify a name for your waf in the wafPlugin custom variable.
This is a non breaking change, as it will default to existing behavior if not specified.

```
custom:
  wafPlugin:
    name: my-really-awesome-waf-name-thanks
```