### PR TITLE
feat(territory support): Adding support to grant all US territories access to CMS applications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ export class WafPlugin {
               },
               Statement: {
                 GeoMatchStatement: {
-                  CountryCodes: ["AS", "GU", "PR", "US", "UM", "VI", "MP"],
+                  CountryCodes: ["AS", "FM", "GU", "MH", "MP", "PR", "PW", "UM", "US", "VI"],
                 },
               },
               VisibilityConfig: {


### PR DESCRIPTION
The MDCT MFP application has reported users seeing a blank screen when accessing the MFP application. They are able to hit other resources such as IDM without issue. Upon investigation it appears that we do not have a country code for American Samoa included in the WAF rules for "allow-use-plus-territories" as well as other US territories. This pr simply updates that list with the appropriate US territories. I've also given this pr a fix title so it can be released with a patch version increase upon merge. 